### PR TITLE
Fixes #43 - using the mithril router without prefix

### DIFF
--- a/helpers/routing/src/router-helper/index.ts
+++ b/helpers/routing/src/router-helper/index.ts
@@ -263,7 +263,7 @@ export function createRouteMap(
 export function createRouter(config: RouterConfig): Router {
   const { routeConfig, createParsePath, defaultRoute } = config;
 
-  const prefix = config.prefix || "#";
+  const prefix = config.hasOwnProperty('prefix') ? config.prefix : "#";
 
   const getPath =
     config.getPath === undefined


### PR DESCRIPTION
This makes the routing helper work as expected when m.route.prefix is set to empty string ("").