### PR TITLE
Specify system emoji fonts for emoji code-points

### DIFF
--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -1,5 +1,9 @@
+@font-face {
+  font-family: "color-emoji";
+  src: local("Apple Color Emoji"), local("Segoe UI Emoji"), local("Segoe UI Symbol"), local("Noto Color Emoji");
+}
 body {
-  font-family: "Lucida Grande",Helvetica,Arial,sans-serif;
+  font-family: "Lucida Grande",Helvetica,Arial,sans-serif,color-emoji;
 }
 .docs-nav {
   display: grid;


### PR DESCRIPTION
Mac OSX & Ubuntu in particular have bugs relating to the proper display of emojis in browsers. Explicitly specifying locally-installed system emoji fonts as fall-backs at the end of the font stack fixes the issue! 🤷

Documented here: https://www.client9.com/css-color-emoji-stack/